### PR TITLE
Update Selenium version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     groovy "org.codehaus.groovy:groovy-all:1.8.6"
 
     def gebVersion = "0.7.2"
-    def seleniumVersion = "2.26.0"
+    def seleniumVersion = "2.31.0"
 
     // If using Spock, need to depend on geb-spock
     testCompile "org.codehaus.geb:geb-spock:$gebVersion"


### PR DESCRIPTION
The Firefox tests weren't running on OS X 10.7.5, even though the tests spawned multiple Firefox instances.  After updating the Selenium version to 2.31.0, the tests run again.

This is against Firefox 19.0.2.
