### PR TITLE
Bump up Selenium version number

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ ext.drivers = ["firefox", "chrome"]
 
 dependencies {
     def gebVersion = "0.9.2"
-    def seleniumVersion = "2.30.0"
+    def seleniumVersion = "2.40.0"
 
     // If using Spock, need to depend on geb-spock
     testCompile "org.gebish:geb-spock:$gebVersion"


### PR DESCRIPTION
The firefoxTest task is broken on Ubuntu 13.10 because of a recent Firefox update. Upgrading to Selenium 2.40.0 fixes this.
