### PR TITLE
Updated versions to work on Java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,12 +9,14 @@ repositories {
 ext.drivers = ["firefox", "chrome"]
 
 dependencies {
-    def gebVersion = "0.9.2"
-    def seleniumVersion = "2.30.0"
-
+    def gebVersion = "0.9.3"
+    def seleniumVersion = "2.42.2"
     // If using Spock, need to depend on geb-spock
     testCompile "org.gebish:geb-spock:$gebVersion"
-    testCompile "org.spockframework:spock-core:0.7-groovy-2.0"
+    testCompile ('org.spockframework:spock-core:0.7-groovy-2.0') {  
+        exclude group: 'org.codehaus.groovy'  
+        }
+    testCompile "org.codehaus.groovy:groovy-all:2.3.4"
 
     // If using JUnit, need to depend on geb-junit (3 or 4)
     testCompile "org.gebish:geb-junit4:$gebVersion"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.0-bin.zip


### PR DESCRIPTION
Updated versions to be compatible with Java 8. Also works with Java 7. 

Got this to work only for Firefox, Chrome was giving errors about the chromedriver (tried using ./gradlew -Dwebdriver.chrome.driver="/Users/erikp/Downloads/chromedriver" chromeTest), and htmlunit (after adding the dependency) was giving errors about failing assertions:

Caused by: Assertion failed: 

$("li.g")
|
[]
