### PR TITLE
Add outputs.upToDateWhen

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ drivers.each { driver ->
             html.destination = reporting.file("$name/tests")
             junitXml.destination = file("$buildDir/test-results/$name")
         }
+        
+        outputs.upToDateWhen { false }  // Always run tests
 
         systemProperty "geb.build.reportsDir", reporting.file("$name/geb")
         systemProperty "geb.env", driver


### PR DESCRIPTION
Especially in this example, seeing no output when running tests a second time is utterly mind-boggling. I use this project as a base for many applications, I change the code under test regularly, but usually don't touch the test-suite. I'd consider a test-suite never ever up to date since you don't know what it's testing.
