### PR TITLE
Version updates: Selenium (for Firefox 36), PhantomJS driver PATCH

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ ext {
     ext {
         groovyVersion = '2.4.1'
         gebVersion = '0.10.0'
-        seleniumVersion = '2.43.1'
+        seleniumVersion = '2.45.0'
         chromeDriverVersion = '2.10'
         phantomJsVersion = '1.9.7'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     // Drivers
     testCompile "org.seleniumhq.selenium:selenium-chrome-driver:$seleniumVersion"
     testCompile "org.seleniumhq.selenium:selenium-firefox-driver:$seleniumVersion"
-    testCompile("com.github.detro.ghostdriver:phantomjsdriver:1.1.0") {
+    testCompile("com.codeborne:phantomjsdriver:1.2.1") {
         // phantomjs driver pulls in a different selenium version
         transitive = false
     }


### PR DESCRIPTION
You may not want to pull this PR directly, but please look at some of the commit comments if you're interested in the details.

* The first commit (update to Selenium 2.45.0) was to make the tests work with Firefox 36. See that commit for the link to the *related Google code issue*.
* The Selenium upgrade breaks PhantomJSDriver and the second commit points to a patched build (which you may not want to use) but also links to *issues with more information*

If you'd like me to submit any of these as separate PR, do squash, etc. -- just let me know.


