### PR TITLE
Update Link to geb configuration documentation

### DIFF
--- a/src/test/resources/GebConfig.groovy
+++ b/src/test/resources/GebConfig.groovy
@@ -1,7 +1,7 @@
 /*
 	This is the Geb configuration file.
 	
-	See: http://www.gebish.org/manual/current/configuration.html
+	See: http://www.gebish.org/manual/current/#configuration
 */
 
 


### PR DESCRIPTION
The structure of geb's documentation seems to have changed.
The link given in the introductory comment of the GebConfig points to an outdated location.