### PR TITLE
Add tasks to download, unzip and use new geckodriver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,9 @@ ext {
     ext {
         groovyVersion = '2.4.8'
         gebVersion = '1.1.1'
-        seleniumVersion = '2.53.0'
+        seleniumVersion = '3.3.1'
         chromeDriverVersion = '2.24'
+        geckoDriverVersion = 'v0.15.0'
         phantomJsVersion = '2.1.1'
     }
 }
@@ -57,6 +58,13 @@ drivers.each { driver ->
         // If you wanted to set the baseUrl in your build…
         // systemProperty "geb.build.baseUrl", "http://myapp.com"
     }
+}
+
+firefoxTest {
+    dependsOn unzipGeckoDriver
+    def geckodriverFilename = Os.isFamily(Os.FAMILY_WINDOWS) ? "geckodriver.exe" : "geckodriver"
+    def geckodriverFile = new File(unzipGeckoDriver.outputs.files.singleFile, geckodriverFilename)
+    systemProperty "webdriver.gecko.driver", geckodriverFile.absolutePath
 }
 
 chromeTest {

--- a/gradle/osSpecificDownloads.gradle
+++ b/gradle/osSpecificDownloads.gradle
@@ -10,6 +10,33 @@ buildscript {
 	}
 }
 
+task downloadGeckoDriver {
+	def outputFile = file("$buildDir/webdriver/geckodriver.tar.gz")
+	inputs.property("geckodriver", geckoDriverVersion)
+	outputs.file(outputFile)
+
+	doLast {
+		def driverOsFilenamePart
+		if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+			driverOsFilenamePart = "win64"
+		} else if (Os.isFamily(Os.FAMILY_MAC)) {
+			driverOsFilenamePart = "macos"
+		} else if (Os.isFamily(Os.FAMILY_UNIX)) {
+			driverOsFilenamePart = "linux64"
+		}
+		FileUtils.copyURLToFile(new URL("https://github.com/mozilla/geckodriver/releases/download/${geckoDriverVersion}/geckodriver-${geckoDriverVersion}-${driverOsFilenamePart}.tar.gz"), outputFile)
+	}
+}
+
+task unzipGeckoDriver(type: Copy) {
+	def outputDir = file("$buildDir/webdriver/geckodriver")
+	dependsOn downloadGeckoDriver
+	outputs.dir(outputDir)
+
+	from(tarTree(downloadGeckoDriver.outputs.files.singleFile))
+	into(outputDir)
+}
+
 task downloadChromeDriver {
 	def outputFile = file("$buildDir/webdriver/chromedriver.zip")
 	inputs.property("chromeDriverVersion", chromeDriverVersion)


### PR DESCRIPTION
This change supports new versions of firefox.
(See http://seleniumsimplified.com/2017/03/changes-in-selenium-webdriver-3-1-0-3-2-0-3-3-0-and-3-3-1-for-java/)