### PR TITLE
Add FirefoxDriver configuration to allow automatic basic auth with http://user:pass@host.tld

### DIFF
--- a/src/test/resources/GebConfig.groovy
+++ b/src/test/resources/GebConfig.groovy
@@ -7,7 +7,10 @@
 
 import org.openqa.selenium.chrome.ChromeDriver
 import org.openqa.selenium.firefox.FirefoxDriver
+import org.openqa.selenium.firefox.FirefoxOptions
+import org.openqa.selenium.firefox.FirefoxProfile
 import org.openqa.selenium.phantomjs.PhantomJSDriver
+import org.openqa.selenium.remote.DesiredCapabilities
 
 waiting {
 	timeout = 2
@@ -26,7 +29,18 @@ environments {
 	firefox {
 		atCheckWaiting = 1
 
-		driver = { new FirefoxDriver() }
+		driver = {
+			FirefoxProfile profile = new FirefoxProfile();
+			// this avoids the "Your are signing in to..." alert
+			profile.setPreference("signon.autologin.proxy", true);
+			
+			DesiredCapabilities desiredCapabilities = new DesiredCapabilities();
+			desiredCapabilities.setCapability('acceptInsecureCerts', true);
+			
+			FirefoxOptions options = new FirefoxOptions().setProfile(profile).addCapabilities(desiredCapabilities);
+			
+			new FirefoxDriver(options)
+		}
 	}
 
     phantomJs {


### PR DESCRIPTION
This configuration allows you to use basic authentification with, for example

```
baseUrl = http://user:password@host.tld
```

Not sure, if you want this to be integrated in your master branch. But if not, this pull request may serve as documentation and example on how to achieve this.