### PR TITLE
Add headless Chrome driver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 ext {
     // The drivers we want to use
-    drivers = ["firefox", "chrome", "phantomJs"]
+    drivers = ["firefox", "chrome", "chromeHeadless", "phantomJs"]
 
     ext {
         groovyVersion = '2.4.12'
@@ -67,11 +67,13 @@ firefoxTest {
     systemProperty "webdriver.gecko.driver", geckodriverFile.absolutePath
 }
 
-chromeTest {
-    dependsOn unzipChromeDriver
+drivers.findAll{it =~ /^chrome.*/}.each { chromeTask ->
+    "${chromeTask}Test" {
+        dependsOn unzipChromeDriver
 
-    def chromedriverFilename = Os.isFamily(Os.FAMILY_WINDOWS) ? "chromedriver.exe" : "chromedriver"
-    systemProperty "webdriver.chrome.driver", new File(unzipChromeDriver.outputs.files.singleFile, chromedriverFilename).absolutePath
+        def chromedriverFilename = Os.isFamily(Os.FAMILY_WINDOWS) ? "chromedriver.exe" : "chromedriver"
+        systemProperty "webdriver.chrome.driver", new File(unzipChromeDriver.outputs.files.singleFile, chromedriverFilename).absolutePath
+    }
 }
 
 phantomJsTest {

--- a/src/test/resources/GebConfig.groovy
+++ b/src/test/resources/GebConfig.groovy
@@ -6,6 +6,7 @@
 
 
 import org.openqa.selenium.chrome.ChromeDriver
+import org.openqa.selenium.chrome.ChromeOptions
 import org.openqa.selenium.firefox.FirefoxDriver
 import org.openqa.selenium.phantomjs.PhantomJSDriver
 
@@ -19,6 +20,16 @@ environments {
 	// See: http://code.google.com/p/selenium/wiki/ChromeDriver
 	chrome {
 		driver = { new ChromeDriver() }
+	}
+
+	// run via “./gradlew chromeHeadlessTest”
+	// See: http://code.google.com/p/selenium/wiki/ChromeDriver
+	chromeHeadless {
+		driver = {
+			ChromeOptions o = new ChromeOptions()
+			o.addArguments('headless')
+			new ChromeDriver(o)
+		}
 	}
 	
 	// run via “./gradlew firefoxTest”


### PR DESCRIPTION
Chrome headless is now (version 60+) supported on Windows and Linux and phantomJS is [no longer](https://groups.google.com/forum/m/#!topic/phantomjs/9aI5d-LDuNE) maintained.