### PR TITLE
Update chromedriver to recent version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
     ext {
         gebVersion = '6.0'
         seleniumVersion = '4.2.2'
-        chromeDriverVersion = '79.0.3945.36'
+        chromeDriverVersion = '105.0.5195.520'
         geckoDriverVersion = '0.31.0'
     }
 }


### PR DESCRIPTION
Updates the chromedriver to v105.0.5195.520. Should [support any version of Chrome v105](https://chromedriver.chromium.org/downloads#:~:text=If%20you%20are%20using%20Chrome%20version%20105%2C%20please%20download%20ChromeDriver%20105.0.5195.52).

Pending [this pull request](https://github.com/webdriverextensions/webdriverextensions-maven-plugin-repository/pull/105) for the webdriver extensions repository.